### PR TITLE
Fix go install command for latest Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL "com.github.actions.color"="gray-dark"
 
 # Install jsonnet-lint
 RUN apk add --no-cache git bash\
-    && go get github.com/google/go-jsonnet/linter/jsonnet-lint
+    && go install github.com/google/go-jsonnet/cmd/jsonnet-lint@latest
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Go get can no longer be used to install a command outside of a module.

https://go.dev/doc/go-get-install-deprecation